### PR TITLE
fix target becomes to None  after random crop

### DIFF
--- a/transforms/geo_aware_transforms.py
+++ b/transforms/geo_aware_transforms.py
@@ -95,6 +95,10 @@ class RandomCrop3D(BaseTransform):
             new_mask = np.array(new_mask)
             updated_mask = np.logical_and(ori_mask, new_mask)
             
+            # to solve the problem: after random crop, the target becomes to None, just return original data
+            if not(new_mask.any()):
+                return data_dict
+            
             # 'gt_bboxes' and 'gt_labels'
             data_dict['label']['gt_bboxes'] = (gt_bboxes * updated_mask[..., np.newaxis])
             data_dict['label']['gt_labels'] *= updated_mask


### PR DESCRIPTION
Hi,
I found a  problem when calculating L1 loss and saw your TODO in l1_loss.py. 
```
# TODO Handling an exception so that it can be handled even when the target data is empty
```
for a clean dataset, the main reason why target becomes to None is going through random crop augmention, so I simplely add a if ( ) in RandomCrop3D. When crop region is empty of target, just return original data and give up this augmention.